### PR TITLE
fix: allow dash to accept google-chrome

### DIFF
--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -9,7 +9,7 @@ var debug = require('debug')('launchpad:local:version');
 
 // Validate paths supplied by the user in order to avoid "arbitrary command execution"
 var validPath = function (filename){
-  var filter = /[`!@#$%^&*()_+\-=\[\]{};'"|,<>?~]/;
+  var filter = /[`!@#$%^&*()_+=\[\]{};'"|,<>?~]/;
   if (filter.test(filename)){
     console.log('\nInvalid characters inside the path to the browser\n');
     return


### PR DESCRIPTION
This should make `"/usr/bin/google-chrome"` work again.