### PR TITLE
fix: allow known browser names with hyphen

### DIFF
--- a/lib/local/version.js
+++ b/lib/local/version.js
@@ -9,8 +9,19 @@ var debug = require('debug')('launchpad:local:version');
 
 // Validate paths supplied by the user in order to avoid "arbitrary command execution"
 var validPath = function (filename){
-  var filter = /[`!@#$%^&*()_+=\[\]{};'"|,<>?~]/;
+  var filter = /[`!@#$%^&*()_+\-=\[\]{};'"|,<>?~]/;
   if (filter.test(filename)){
+    // Browsers known to contain hyphen
+    var KNOWN_NAMES = ['google-chrome', 'chromium-browser', 'microsoft-edge'];
+
+    var nameMatches = function(name) {
+      return filename.indexOf(name) !== -1;
+    };
+
+    // Ensure there is only one hyphen
+    if (filename.split('-').length == 2 && KNOWN_NAMES.some(nameMatches)) {
+      return filename;
+    }
     console.log('\nInvalid characters inside the path to the browser\n');
     return
   }


### PR DESCRIPTION
Restore the RegExp but allow certain browser names known to contain hyphen if and only if that's the only hyphen.